### PR TITLE
Using state 'present' instead of 'installed'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: ensure snmpd is installed
-  apt: pkg=snmpd state=installed
+  apt: pkg=snmpd state=present
 
 - name: configure snmpd
   template: src=snmpd.conf.j2 dest=/etc/snmp/snmpd.conf


### PR DESCRIPTION
To mediate the following deprecation warning.
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.. This feature will be removed in version 2.9.