### PR TITLE
Use state='started' instead of 'running'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,4 +8,4 @@
     - restart snmpd
 
 - name: ensure snmpd is enabled and running
-  service: name=snmpd enabled=yes state=running
+  service: name=snmpd enabled=yes state=started


### PR DESCRIPTION
To mediate the following deprecation warning:
[DEPRECATION WARNING]: state=running is deprecated. Please use state=started. This feature will be removed in version 2.7.